### PR TITLE
Fix: select kernel_modules_headers instead of kernel_source if Balena OS version greater than 2.x.x

### DIFF
--- a/gpu/Dockerfile
+++ b/gpu/Dockerfile
@@ -27,8 +27,9 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 # Download the kernel source then prepare kernel source to build a module.
 RUN \
-    curl -fsSL "https://files.balena-cloud.com/images/${BALENA_MACHINE_NAME}/${VERSION}/kernel_source.tar.gz" \
-        | tar xz --strip-components=2 && \
+    [ "${VERSION%%.*}" -gt "2" ] && FILE_NAME="kernel_modules_headers.tar.gz" || FILE_NAME="kernel_source.tar.gz" && \
+    curl -fsSL "https://files.balena-cloud.com/images/${BALENA_MACHINE_NAME}/${VERSION}/${FILE_NAME}" \
+    | tar xz --strip-components=2 && \
     make -C build modules_prepare -j"$(nproc)"
 
 # required if using install-libglvnd from nvidia-installer below


### PR DESCRIPTION
fixes #8 

- `kernel_source.tar.gz` is not available for Balena versions `3.x.x+` in https://files.balena-cloud.com/ , however the headers are available.
- Found the correct file name from [balena-os/kernel-module-build](https://github.com/balena-os/kernel-module-build/blob/6f44f80cef9d6c2ab51319aaac95795362555fe9/module/build.sh#L35C2-L35C90)
- Feel free to improve the shell script not an expert
  - it selects `kernel_modules_drivers.tar.gz` from Balena cloud if version is greater than `3.x.x`
 
tested building with Balena OS version `4.1.5+rev1`